### PR TITLE
fix SortInputs

### DIFF
--- a/Utils.go
+++ b/Utils.go
@@ -3,7 +3,6 @@ package apollo
 import (
 	"encoding/hex"
 	"sort"
-	"strconv"
 
 	"github.com/SundaeSwap-finance/apollo/serialization/UTxO"
 )
@@ -30,30 +29,16 @@ type txIn struct {
 }
 
 func SortInputs(inputs []UTxO.UTxO) []UTxO.UTxO {
-	txIns := make([]txIn, 0)
-	relationMap := map[string]UTxO.UTxO{}
-	for _, utxo := range inputs {
-		newTxIn := txIn{
-			id: hex.EncodeToString(utxo.Input.TransactionId),
-			ix: utxo.Input.Index,
-		}
-		txIns = append(txIns, newTxIn)
-		key := newTxIn.id + strconv.Itoa(newTxIn.ix)
-		relationMap[key] = utxo
-	}
-	sort.Slice(txIns, func(i, j int) bool {
-		if txIns[i].id < txIns[j].id {
-			return true
-		} else if txIns[i].id > txIns[j].id {
-			return false
+	sortedInputs := make([]UTxO.UTxO, 0)
+	sortedInputs = append(sortedInputs, inputs...)
+	sort.Slice(sortedInputs, func(i, j int) bool {
+		iTxId := hex.EncodeToString(sortedInputs[i].Input.TransactionId)
+		jTxId := hex.EncodeToString(sortedInputs[j].Input.TransactionId)
+		if iTxId != jTxId {
+			return iTxId < jTxId
 		} else {
-			return txIns[i].ix < txIns[j].ix
+			return sortedInputs[i].Input.Index < sortedInputs[j].Input.Index
 		}
 	})
-	sorted_inputs := make([]UTxO.UTxO, 0)
-	for _, txIn := range txIns {
-		key := txIn.id + strconv.Itoa(txIn.ix)
-		sorted_inputs = append(sorted_inputs, relationMap[key])
-	}
-	return sorted_inputs
+	return sortedInputs
 }


### PR DESCRIPTION
The old implementation sorted lexicographically, which can give incorrect results if two inputs share the same tx hash and one of the inputs has an index of 10 or greater, e.g.:
```
5f9883d23e59e6f905061622761bda8aeb9d1c560cb1ee93c1d82f572d5099de#10
5f9883d23e59e6f905061622761bda8aeb9d1c560cb1ee93c1d82f572d5099de#2
```
this list would have been considered sorted.