### PR TITLE
Surface kupo errors to callers

### DIFF
--- a/ApolloBuilder.go
+++ b/ApolloBuilder.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"log"
 	"strconv"
 
 	"github.com/Salvionied/cbor/v2"
@@ -311,9 +310,9 @@ func (b *Apollo) buildFakeWitnessSet() TransactionWitnessSet.TransactionWitnessS
 	}
 }
 
-func (b *Apollo) scriptDataHash() *serialization.ScriptDataHash {
+func (b *Apollo) scriptDataHash() (*serialization.ScriptDataHash, error) {
 	if len(b.datums) == 0 && len(b.redeemers) == 0 {
-		return nil
+		return nil, nil
 	}
 	witnessSet := b.buildWitnessSet()
 	cost_models := map[cbor.Marshaler]cbor.Marshaler{}
@@ -329,13 +328,13 @@ func (b *Apollo) scriptDataHash() *serialization.ScriptDataHash {
 	//redeemer_bytes, err := cbor.Marshal(Redeemer.Redeemers{Redeemers: redeemers})
 	redeemer_bytes, err := cbor.Marshal(redeemers)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	var datum_bytes []byte
 	if datums.Len() > 0 {
 		datum_bytes, err = cbor.Marshal(datums)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("error marshalling CBOR: %v", err)
 		}
 	} else {
 		datum_bytes = []byte{}
@@ -353,11 +352,11 @@ func (b *Apollo) scriptDataHash() *serialization.ScriptDataHash {
 	}
 	cost_model_bytes, err = cbor.Marshal(cost_models)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("error marshalling cost models: %v", err)
 	}
 	total_bytes := append(redeemer_bytes, datum_bytes...)
 	total_bytes = append(total_bytes, cost_model_bytes...)
-	return &serialization.ScriptDataHash{Payload: serialization.Blake2bHash(total_bytes)}
+	return &serialization.ScriptDataHash{Payload: serialization.Blake2bHash(total_bytes)}, nil
 }
 
 func (b *Apollo) getMints() MultiAsset.MultiAsset[int64] {
@@ -385,7 +384,7 @@ func (b *Apollo) MintAssetsWithRedeemer(mintUnit Unit, redeemerData PlutusData.P
 	return b
 }
 
-func (b *Apollo) buildTxBody() TransactionBody.TransactionBody {
+func (b *Apollo) buildTxBody() (TransactionBody.TransactionBody, error) {
 	inputs := make([]TransactionInput.TransactionInput, 0)
 	for _, utxo := range b.preselectedUtxos {
 		inputs = append(inputs, utxo.Input)
@@ -394,7 +393,10 @@ func (b *Apollo) buildTxBody() TransactionBody.TransactionBody {
 	for _, utxo := range b.collaterals {
 		collaterals = append(collaterals, utxo.Input)
 	}
-	dataHash := b.scriptDataHash()
+	dataHash, err := b.scriptDataHash()
+	if err != nil {
+		return TransactionBody.TransactionBody{}, err
+	}
 	scriptDataHash := make([]byte, 0)
 	if dataHash != nil {
 		scriptDataHash = dataHash.Payload
@@ -423,11 +425,14 @@ func (b *Apollo) buildTxBody() TransactionBody.TransactionBody {
 		txb.TotalCollateral = b.totalCollateral
 		txb.CollateralReturn = b.collateralReturn
 	}
-	return txb
+	return txb, nil
 }
 
 func (b *Apollo) buildFullFakeTx() (*Transaction.Transaction, error) {
-	txBody := b.buildTxBody()
+	txBody, err := b.buildTxBody()
+	if err != nil {
+		return nil, err
+	}
 	if txBody.Fee == 0 {
 		txBody.Fee = int64(b.Context.MaxTxFee())
 	}
@@ -706,7 +711,10 @@ func (b *Apollo) Complete() (*Apollo, []byte, error) {
 		return b, tx_cbor, err
 	}
 	//FINALIZE TX
-	body := b.buildTxBody()
+	body, err := b.buildTxBody()
+	if err != nil {
+		return b, tx_cbor, err
+	}
 	witnessSet := b.buildWitnessSet()
 	b.tx = &Transaction.Transaction{TransactionBody: body, TransactionWitnessSet: witnessSet, AuxiliaryData: b.auxiliaryData, Valid: true}
 	return b, nil, nil
@@ -1009,8 +1017,10 @@ func (b *Apollo) SetWalletAsChangeAddress() *Apollo {
 	switch b.Context.(type) {
 	case *BlockFrostChainContext.BlockFrostChainContext:
 
-		utxos := b.Context.Utxos(*b.wallet.GetAddress())
-		b = b.AddLoadedUTxOs(utxos...)
+		utxos, err := b.Context.Utxos(*b.wallet.GetAddress())
+		if err != nil {
+			b = b.AddLoadedUTxOs(utxos...)
+		}
 	default:
 	}
 	b.inputAddresses = append(b.inputAddresses, *b.wallet.GetAddress())

--- a/txBuilding/Backend/Base/Base.go
+++ b/txBuilding/Backend/Base/Base.go
@@ -188,7 +188,7 @@ type ChainContext interface {
 	Epoch() int
 	MaxTxFee() int
 	LastBlockSlot() int
-	Utxos(address Address.Address) []UTxO.UTxO
+	Utxos(address Address.Address) ([]UTxO.UTxO, error)
 	SubmitTx(Transaction.Transaction) (serialization.TransactionId, error)
 	EvaluateTx([]uint8) (map[string]Redeemer.ExecutionUnits, error)
 	EvaluateTxWithAdditionalUtxos([]uint8, []UTxO.UTxO) (map[string]Redeemer.ExecutionUnits, error)

--- a/txBuilding/Backend/BlockFrostChainContext/BlockFrostChainContext.go
+++ b/txBuilding/Backend/BlockFrostChainContext/BlockFrostChainContext.go
@@ -144,7 +144,7 @@ func (bfc *BlockFrostChainContext) LatestEpoch() Base.Epoch {
 		return res
 	}
 }
-func (bfc *BlockFrostChainContext) AddressUtxos(address string, gather bool) []Base.AddressUTXO {
+func (bfc *BlockFrostChainContext) AddressUtxos(address string, gather bool) ([]Base.AddressUTXO, error) {
 	if gather {
 		var i = 1
 		result := make([]Base.AddressUTXO, 0)
@@ -153,7 +153,7 @@ func (bfc *BlockFrostChainContext) AddressUtxos(address string, gather bool) []B
 			req.Header.Set("project_id", bfc._projectId)
 			res, err := bfc.client.Do(req)
 			if err != nil {
-				log.Fatal(err, "REQUEST PROTOCOL")
+				return result, fmt.Errorf("REQUEST PROTOCOL: %v", err)
 			}
 			body, err := ioutil.ReadAll(res.Body)
 			var response []Base.AddressUTXO
@@ -162,26 +162,26 @@ func (bfc *BlockFrostChainContext) AddressUtxos(address string, gather bool) []B
 				break
 			}
 			if err != nil {
-				log.Fatal(err, "UNMARSHAL PROTOCOL")
+				return result, fmt.Errorf("UNMARSHAL PROTOCOL: %v", err)
 			}
 			result = append(result, response...)
 			i++
 		}
-		return result
+		return result, nil
 	} else {
 		req, _ := http.NewRequest("GET", fmt.Sprintf("%s/v0/addresses/%s/utxos", bfc._baseUrl, address), nil)
 		req.Header.Set("project_id", bfc._projectId)
 		res, err := bfc.client.Do(req)
+		var response []Base.AddressUTXO
 		if err != nil {
-			log.Fatal(err, "REQUEST PROTOCOL")
+			return response, fmt.Errorf("REQUEST PROTOCOL: %v", err)
 		}
 		body, err := ioutil.ReadAll(res.Body)
-		var response []Base.AddressUTXO
 		err = json.Unmarshal(body, &response)
 		if err != nil {
-			log.Fatal(err, "UNMARSHAL PROTOCOL")
+			return response, fmt.Errorf("UNMARSHAL PROTOCOL: %v", err)
 		}
-		return response
+		return response, nil
 	}
 }
 
@@ -292,9 +292,12 @@ func (bfc *BlockFrostChainContext) MaxTxFee() int {
 	return Base.Fee(bfc, protocol_param.MaxTxSize, maxTxExSteps, maxTxExMem)
 }
 
-func (bfc *BlockFrostChainContext) Utxos(address Address.Address) []UTxO.UTxO {
-	results := bfc.AddressUtxos(address.String(), true)
+func (bfc *BlockFrostChainContext) Utxos(address Address.Address) ([]UTxO.UTxO, error) {
+	results, err := bfc.AddressUtxos(address.String(), true)
 	utxos := make([]UTxO.UTxO, 0)
+	if err != nil {
+		return utxos, err
+	}
 	for _, result := range results {
 		decodedTxId, _ := hex.DecodeString(result.TxHash)
 		tx_in := TransactionInput.TransactionInput{TransactionId: decodedTxId, Index: result.OutputIndex}
@@ -305,13 +308,13 @@ func (bfc *BlockFrostChainContext) Utxos(address Address.Address) []UTxO.UTxO {
 			if item.Unit == "lovelace" {
 				amount, err := strconv.Atoi(item.Quantity)
 				if err != nil {
-					log.Fatal(err)
+					return utxos, err
 				}
 				lovelace_amount += amount
 			} else {
 				asset_quantity, err := strconv.ParseInt(item.Quantity, 10, 64)
 				if err != nil {
-					log.Fatal(err)
+					return utxos, err
 				}
 				policy_id := Policy.PolicyId{Value: item.Unit[:56]}
 				asset_name := *AssetName.NewAssetNameFromHexString(item.Unit[56:])
@@ -338,12 +341,12 @@ func (bfc *BlockFrostChainContext) Utxos(address Address.Address) []UTxO.UTxO {
 		if result.InlineDatum != "" {
 			decoded, err := hex.DecodeString(result.InlineDatum)
 			if err != nil {
-				log.Fatal(err)
+				return utxos, err
 			}
 			var x PlutusData.PlutusData
 			err = cbor.Unmarshal(decoded, &x)
 			if err != nil {
-				log.Fatal(err)
+				return utxos, err
 			}
 			l := PlutusData.DatumOptionInline(&x)
 			tx_out = TransactionOutput.TransactionOutput{IsPostAlonzo: true,
@@ -361,7 +364,7 @@ func (bfc *BlockFrostChainContext) Utxos(address Address.Address) []UTxO.UTxO {
 		}
 		utxos = append(utxos, UTxO.UTxO{Input: tx_in, Output: tx_out})
 	}
-	return utxos
+	return utxos, nil
 }
 func (bfc *BlockFrostChainContext) SpecialSubmitTx(tx Transaction.Transaction, logger chan string) serialization.TransactionId {
 	txBytes, _ := cbor.Marshal(tx)
@@ -409,13 +412,13 @@ func (bfc *BlockFrostChainContext) SubmitTx(tx Transaction.Transaction) (seriali
 			req.Header.Set("Content-Type", "application/cbor")
 			res, err := bfc.client.Do(req)
 			if err != nil {
-				log.Fatal(err, "REQUEST PROTOCOL")
+				return serialization.TransactionId{}, fmt.Errorf("REQUEST PROTOCOL: %v", err)
 			}
 			body, err := ioutil.ReadAll(res.Body)
 			var response any
 			err = json.Unmarshal(body, &response)
 			if err != nil {
-				log.Fatal(err, "UNMARSHAL PROTOCOL")
+				return serialization.TransactionId{}, fmt.Errorf("UNMARSHAL PROTOCOL: %v", err)
 			}
 		}
 	}
@@ -424,7 +427,7 @@ func (bfc *BlockFrostChainContext) SubmitTx(tx Transaction.Transaction) (seriali
 	req.Header.Set("Content-Type", "application/cbor")
 	res, err := bfc.client.Do(req)
 	if err != nil {
-		log.Fatal(err, "REQUEST PROTOCOL")
+		return serialization.TransactionId{}, fmt.Errorf("REQUEST PROTOCOL: %v", err)
 	}
 	body, err := ioutil.ReadAll(res.Body)
 	var response any

--- a/txBuilding/Backend/FixedChainContext/FixedChainContext.go
+++ b/txBuilding/Backend/FixedChainContext/FixedChainContext.go
@@ -111,7 +111,7 @@ func (f FixedChainContext) GetUtxoFromRef(txHash string, txIndex int) (UTxO.UTxO
 	return UTxO.UTxO{}, nil
 }
 
-func (f FixedChainContext) Utxos(address Address.Address) []UTxO.UTxO {
+func (f FixedChainContext) Utxos(address Address.Address) ([]UTxO.UTxO, error) {
 	tx_in1 := TransactionInput.TransactionInput{
 		TransactionId: []byte{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01},
 		Index:         0,
@@ -123,7 +123,7 @@ func (f FixedChainContext) Utxos(address Address.Address) []UTxO.UTxO {
 
 	tx_out1 := TransactionOutput.SimpleTransactionOutput(address, Value.PureLovelaceValue(5000000))
 	tx_out2 := TransactionOutput.SimpleTransactionOutput(address, Value.SimpleValue(6000000, MultiAsset.MultiAsset[int64]{Policy.PolicyId{Value: "11111111111111111111111111111111111111111111111111111111"}: Asset.Asset[int64]{AssetName.NewAssetNameFromString("Token1"): 1, AssetName.NewAssetNameFromString("Token2"): 2}}))
-	return []UTxO.UTxO{{Input: tx_in1, Output: tx_out1}, {Input: tx_in2, Output: tx_out2}}
+	return []UTxO.UTxO{{Input: tx_in1, Output: tx_out1}, {Input: tx_in2, Output: tx_out2}}, nil
 }
 
 func (f FixedChainContext) SubmitTx(tx Transaction.Transaction) (serialization.TransactionId, error) {

--- a/txBuilding/Backend/MaestroChainContext/MaestroChainContext.go
+++ b/txBuilding/Backend/MaestroChainContext/MaestroChainContext.go
@@ -119,10 +119,10 @@ func (mcc *MaestroChainContext) MaxTxFee() int {
 	return Base.Fee(mcc, protocol_param.MaxTxSize, maxTxExSteps, maxTxExMem)
 }
 
-func (mcc *MaestroChainContext) Utxos(address Address.Address) []UTxO.UTxO {
+func (mcc *MaestroChainContext) Utxos(address Address.Address) ([]UTxO.UTxO, error) {
 	utxos := make([]UTxO.UTxO, 0)
 	//TODO
-	return utxos
+	return utxos, nil
 }
 
 func (mcc *MaestroChainContext) SubmitTx(tx Transaction.Transaction) (serialization.TransactionId, error) {

--- a/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
+++ b/txBuilding/Backend/OgmiosChainContext/OgmiosChainContext.go
@@ -53,13 +53,13 @@ func NewOgmiosChainContext(ogmigoClient ogmigo.Client, kugoClient kugo.Client) O
 }
 
 func (occ *OgmiosChainContext) Init() {
-	latest_epochs := occ.LatestEpoch()
+	latest_epochs, _ := occ.LatestEpoch()
 	occ._epoch_info = latest_epochs
 	//Init Genesis
 	params := occ.GenesisParams()
 	occ._genesis_param = params
 	//init epoch
-	latest_params := occ.LatestEpochParams()
+	latest_params, _ := occ.LatestEpochParams()
 	occ._protocol_param = latest_params
 }
 
@@ -273,7 +273,7 @@ func (occ *OgmiosChainContext) GetUtxoFromRef(txHash string, index int) (UTxO.UT
 		Index: uint32(index),
 	})
 	if err != nil {
-		log.Fatal(err, "REQUEST PROTOCOL")
+		return UTxO.UTxO{}, fmt.Errorf("could not fetch utxo: %v#%v: %v", txHash, index, err)
 	}
 	if len(utxos) == 0 {
 		return UTxO.UTxO{}, fmt.Errorf("Could not fetch utxo: %v#%v", txHash, index)
@@ -376,54 +376,57 @@ func computeEndTime(epoch uint64, networkStartTime time.Time, history *ogmigo.Er
 
 // Because ogmios does not return the end time when querying the current epoch,
 // we have to dig through the era summaries and query the network start time
-func (occ *OgmiosChainContext) LatestEpoch() Base.Epoch {
+func (occ *OgmiosChainContext) LatestEpoch() (Base.Epoch, error) {
 	ctx := context.Background()
 	current, err := occ.ogmigo.CurrentEpoch(ctx)
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpoch: failed to request current epoch")
+		return Base.Epoch{}, fmt.Errorf("OgmiosChainContext: LatestEpoch: failed to request current epoch: %v", err)
 	}
 	genesisConfig, err := occ.ogmigo.GenesisConfig(ctx, "byron")
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpoch: failed to request genesis config")
+		return Base.Epoch{}, fmt.Errorf("OgmiosChainContext: LatestEpoch: failed to request genesis config: %v", err)
 	}
 	var genesisInfo struct {
 		StartTime string
 	}
 	err = json.Unmarshal(genesisConfig, &genesisInfo)
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpoch: failed to parse genesis config")
+		return Base.Epoch{}, fmt.Errorf("OgmiosChainContext: LatestEpoch: failed to parse genesis config: %v", err)
 	}
 	startTime, err := time.Parse(time.RFC3339, genesisInfo.StartTime)
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpoch: failed to parse genesis config startTime")
+		return Base.Epoch{}, fmt.Errorf("OgmiosChainContext: LatestEpoch: failed to parse genesis config startTime: %v", err)
 	}
 	eraSummaries, err := occ.ogmigo.EraSummaries(ctx)
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpoch: failed to request era summaries")
+		return Base.Epoch{}, fmt.Errorf("OgmiosChainContext: LatestEpoch: failed to request era summaries: %v", err)
 	}
 	endTime, err := computeEndTime(current, startTime, eraSummaries)
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpoch: failed to compute end time for epoch")
+		return Base.Epoch{}, fmt.Errorf("OgmiosChainContext: LatestEpoch: failed to compute end time for epoch: %v", err)
 	}
 	return Base.Epoch{
 		Epoch:   int(current),
 		EndTime: int(endTime),
-	}
+	}, nil
 }
 
-func (occ *OgmiosChainContext) KupoToUtxo(m kugo.Match) UTxO.UTxO {
+func (occ *OgmiosChainContext) KupoToUtxo(m kugo.Match) (UTxO.UTxO, error) {
 	ctx := context.Background()
-	addr, au := occ.kupoToAddressUtxo(ctx, m)
+	addr, au, err := occ.kupoToAddressUtxo(ctx, m)
+	if err != nil {
+		return UTxO.UTxO{}, err
+	}
 	return occ.addressUtxoToUtxo(ctx, addr, au)
 }
 
-func (occ *OgmiosChainContext) kupoToAddressUtxo(ctx context.Context, match kugo.Match) (Address.Address, Base.AddressUTXO) {
+func (occ *OgmiosChainContext) kupoToAddressUtxo(ctx context.Context, match kugo.Match) (Address.Address, Base.AddressUTXO, error) {
 	datum := ""
 	var err error
 	if match.DatumType == "inline" {
 		datum, err = occ.kugo.Datum(ctx, match.DatumHash)
 		if err != nil {
-			log.Fatal(err, "OgmiosChainContext: AddressUtxos: kupo datum request failed")
+			return Address.Address{}, Base.AddressUTXO{}, fmt.Errorf("OgmiosChainContext: AddressUtxos: kupo datum request failed: %v", err)
 		}
 	}
 	am := ogmiosValue_toAddressAmount(shared.Value(match.Value))
@@ -437,22 +440,24 @@ func (occ *OgmiosChainContext) kupoToAddressUtxo(ctx context.Context, match kugo
 		DataHash:            match.DatumHash,
 		InlineDatum:         datum,
 		ReferenceScriptHash: match.ScriptHash,
-	}
+	}, nil
 }
 
-func (occ *OgmiosChainContext) AddressUtxos(address string, gather bool) []Base.AddressUTXO {
+func (occ *OgmiosChainContext) AddressUtxos(address string, gather bool) ([]Base.AddressUTXO, error) {
 	ctx := context.Background()
 	addressUtxos := make([]Base.AddressUTXO, 0)
 	matches, err := occ.kugo.Matches(ctx, kugo.OnlyUnspent(), kugo.Address(address))
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: AddressUtxos: kupo request failed")
+		return addressUtxos, fmt.Errorf("OgmiosChainContext: AddressUtxos: kupo request failed: %v", err)
 	}
 	for _, match := range matches {
-		_, addrUtxo := occ.kupoToAddressUtxo(ctx, match)
+		_, addrUtxo, err := occ.kupoToAddressUtxo(ctx, match)
+		if err != nil {
+			return nil, err
+		}
 		addressUtxos = append(addressUtxos, addrUtxo)
 	}
-	return addressUtxos
-
+	return addressUtxos, nil
 }
 
 type AdaLovelace struct {
@@ -599,16 +604,16 @@ func ratio(s string) float32 {
 	return float32(num) / float32(den)
 }
 
-func (occ *OgmiosChainContext) LatestEpochParams() Base.ProtocolParameters {
+func (occ *OgmiosChainContext) LatestEpochParams() (Base.ProtocolParameters, error) {
 	ctx := context.Background()
 	pparams, err := occ.ogmigo.CurrentProtocolParameters(ctx)
 	if err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpochParams: protocol parameters request failed")
+		return Base.ProtocolParameters{}, fmt.Errorf("OgmiosChainContext: LatestEpochParams: protocol parameters request failed: %v", err)
 	}
 
 	var ogmiosParams OgmiosProtocolParameters
 	if err := json.Unmarshal(pparams, &ogmiosParams); err != nil {
-		log.Fatal(err, "OgmiosChainContext: LatestEpochParams: failed to parse protocol parameters")
+		return Base.ProtocolParameters{}, fmt.Errorf("OgmiosChainContext: LatestEpochParams: failed to parse protocol parameters: %v", err)
 	}
 
 	cm := map[Base.CostModelsPlutusVersion]PlutusData.CostModel{
@@ -650,7 +655,7 @@ func (occ *OgmiosChainContext) LatestEpochParams() Base.ProtocolParameters {
 		CoinsPerUtxoWord:       strconv.FormatUint(ogmiosParams.MinUtxoDepositCoefficient, 10),
 		MinFeeReferenceScripts: int(ogmiosParams.MinFeeReferenceScripts.Base),
 		CostModels:             cm,
-	}
+	}, nil
 }
 
 func (occ *OgmiosChainContext) GenesisParams() Base.GenesisParameters {
@@ -660,7 +665,11 @@ func (occ *OgmiosChainContext) GenesisParams() Base.GenesisParameters {
 }
 func (occ *OgmiosChainContext) _CheckEpochAndUpdate() bool {
 	if occ._epoch_info.EndTime <= int(time.Now().Unix()) {
-		latest_epochs := occ.LatestEpoch()
+		latest_epochs, err := occ.LatestEpoch()
+		if err != nil {
+			log.Printf("warning: could not get latest epoch: %v", err)
+			return false
+		}
 		occ._epoch_info = latest_epochs
 		return true
 	}
@@ -673,7 +682,11 @@ func (occ *OgmiosChainContext) Network() int {
 
 func (occ *OgmiosChainContext) Epoch() int {
 	if occ._CheckEpochAndUpdate() {
-		new_epoch := occ.LatestEpoch()
+		new_epoch, err := occ.LatestEpoch()
+		if err != nil {
+			log.Printf("warning: could not get latest epoch: %v", err)
+			return occ._epoch
+		}
 		occ._epoch = new_epoch.Epoch
 	}
 	return occ._epoch
@@ -695,8 +708,12 @@ func (occ *OgmiosChainContext) GetGenesisParams() Base.GenesisParameters {
 
 func (occ *OgmiosChainContext) GetProtocolParams() Base.ProtocolParameters {
 	if occ._CheckEpochAndUpdate() {
-		latest_params := occ.LatestEpochParams()
-		occ._protocol_param = latest_params
+		latest_params, err := occ.LatestEpochParams()
+		if err != nil {
+			log.Printf("warning: could not get protocol params: %v\n", err)
+		} else {
+			occ._protocol_param = latest_params
+		}
 	}
 	return occ._protocol_param
 }
@@ -708,7 +725,7 @@ func (occ *OgmiosChainContext) MaxTxFee() int {
 	return Base.Fee(occ, protocol_param.MaxTxSize, maxTxExSteps, maxTxExMem)
 }
 
-func (occ *OgmiosChainContext) addressUtxoToUtxo(ctx context.Context, address Address.Address, result Base.AddressUTXO) UTxO.UTxO {
+func (occ *OgmiosChainContext) addressUtxoToUtxo(ctx context.Context, address Address.Address, result Base.AddressUTXO) (UTxO.UTxO, error) {
 	decodedTxId, _ := hex.DecodeString(result.TxHash)
 	tx_in := TransactionInput.TransactionInput{TransactionId: decodedTxId, Index: result.OutputIndex}
 	amount := result.Amount
@@ -718,13 +735,13 @@ func (occ *OgmiosChainContext) addressUtxoToUtxo(ctx context.Context, address Ad
 		if item.Unit == "lovelace" {
 			amount, err := strconv.Atoi(item.Quantity)
 			if err != nil {
-				log.Fatal(err)
+				return UTxO.UTxO{}, err
 			}
 			lovelace_amount += amount
 		} else {
 			asset_quantity, err := strconv.ParseInt(item.Quantity, 10, 64)
 			if err != nil {
-				log.Fatal(err)
+				return UTxO.UTxO{}, err
 			}
 			policy_id := Policy.PolicyId{Value: item.Unit[:56]}
 			asset_name := *AssetName.NewAssetNameFromHexString(item.Unit[56:])
@@ -753,11 +770,11 @@ func (occ *OgmiosChainContext) addressUtxoToUtxo(ctx context.Context, address Ad
 	if result.ReferenceScriptHash != "" {
 		ref, err := occ.kugo.Script(ctx, result.ReferenceScriptHash)
 		if err != nil {
-			log.Fatal(fmt.Errorf("OgmiosChainContext: failed to query reference script hash: '%v': %w", result.ReferenceScriptHash, err))
+			return UTxO.UTxO{}, fmt.Errorf("OgmiosChainContext: failed to query reference script hash: '%v': %w", result.ReferenceScriptHash, err)
 		}
 		raw, err := hex.DecodeString(ref.Script)
 		if err != nil {
-			log.Fatal(fmt.Errorf("OgmiosChainContext: failed to decode reference script bytes from hex: %w", err))
+			return UTxO.UTxO{}, fmt.Errorf("OgmiosChainContext: failed to decode reference script bytes from hex: %w", err)
 		}
 		refScript = raw
 	}
@@ -767,12 +784,12 @@ func (occ *OgmiosChainContext) addressUtxoToUtxo(ctx context.Context, address Ad
 	if result.InlineDatum != "" {
 		decoded, err := hex.DecodeString(result.InlineDatum)
 		if err != nil {
-			log.Fatal(err)
+			return UTxO.UTxO{}, err
 		}
 		var x PlutusData.PlutusData
 		err = cbor.Unmarshal(decoded, &x)
 		if err != nil {
-			log.Fatal(err)
+			return UTxO.UTxO{}, err
 		}
 		option := PlutusData.DatumOptionInline(&x)
 		inlineDatum = &option
@@ -809,19 +826,26 @@ func (occ *OgmiosChainContext) addressUtxoToUtxo(ctx context.Context, address Ad
 	return UTxO.UTxO{
 		Input:  tx_in,
 		Output: tx_out,
-	}
+	}, nil
 }
 
 // Copied from blockfrost context def since it just calls AddressUtxos and then
 // converts
-func (occ *OgmiosChainContext) Utxos(address Address.Address) []UTxO.UTxO {
+func (occ *OgmiosChainContext) Utxos(address Address.Address) ([]UTxO.UTxO, error) {
 	ctx := context.Background()
-	results := occ.AddressUtxos(address.String(), true)
+	results, err := occ.AddressUtxos(address.String(), true)
 	utxos := make([]UTxO.UTxO, 0)
-	for _, result := range results {
-		utxos = append(utxos, occ.addressUtxoToUtxo(ctx, address, result))
+	if err != nil {
+		return utxos, err
 	}
-	return utxos
+	for _, result := range results {
+		utxo, err := occ.addressUtxoToUtxo(ctx, address, result)
+		if err != nil {
+			return utxos, err
+		}
+		utxos = append(utxos, utxo)
+	}
+	return utxos, nil
 }
 
 func (occ *OgmiosChainContext) SubmitTx(tx Transaction.Transaction) (serialization.TransactionId, error) {


### PR DESCRIPTION
Update all (used) code paths in ApolloBuilder and OgmiosChainContext to propagate network errors instead of using `log.Fatal`. Deserialization errors are still allowed to use `log.Fatal`, because those are unrecoverable anyway. 
This is a breaking change, but that's for the best.