### PR TITLE
Pass V1/V2 cost models through without hardcoded key lists

### DIFF
--- a/serialization/PlutusData/PlutusData.go
+++ b/serialization/PlutusData/PlutusData.go
@@ -1129,19 +1129,29 @@ func CostModelV3(cm CostModel) cbor.Marshaler {
 }
 
 func CostModelV2(cm CostModel) cbor.Marshaler {
-	cost := make(map[string]int)
-	for ix, s := range V2COSTMODELKEYS {
-		cost[s] = cm[ix]
+	return cm
+}
+
+// CostModelV1Encoding produces the CIP-35 Alonzo V1 language-view encoding:
+// a CBOR bytestring wrapping an indefinite-length array of the cost model
+// integers in canonical parameter order.
+type CostModelV1Encoding CostModel
+
+func (cm CostModelV1Encoding) MarshalCBOR() ([]byte, error) {
+	inner := []byte{0x9f}
+	for _, v := range cm {
+		chunk, err := cbor.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		inner = append(inner, chunk...)
 	}
-	return CostView(cost)
+	inner = append(inner, 0xff)
+	return cbor.Marshal(inner)
 }
 
 func CostModelV1(cm CostModel) cbor.Marshaler {
-	cost := make(map[string]int)
-	for ix, s := range V1COSTMODELKEYS {
-		cost[s] = cm[ix]
-	}
-	return CM(cost)
+	return CostModelV1Encoding(cm)
 }
 
 type PlutusType int

--- a/tests/serialization/PlutusData/PlutusData_test.go
+++ b/tests/serialization/PlutusData/PlutusData_test.go
@@ -507,3 +507,124 @@ func TestStablePoolDatumWithLargeSumInvariant(t *testing.T) {
 		t.Log("Successfully round-tripped stableswap datum with large SumInvariant")
 	}
 }
+
+// decodeCostModelV1 parses the output of CostModelV1Encoding.MarshalCBOR
+// back into the integer sequence it wrapped.
+func decodeCostModelV1(t *testing.T, encoded []byte) []int {
+	t.Helper()
+	var inner []byte
+	if err := cbor.Unmarshal(encoded, &inner); err != nil {
+		t.Fatalf("outer bytestring unmarshal failed: %v", err)
+	}
+	if len(inner) < 2 || inner[0] != 0x9f || inner[len(inner)-1] != 0xff {
+		t.Fatalf("inner bytes not an indefinite-length CBOR array: %x", inner)
+	}
+	// Re-wrap as a definite-length array decode by swapping the indefinite
+	// markers for a definite-length header computed from the integer count,
+	// or just decode directly — the Salvionied/cbor library accepts
+	// indefinite arrays.
+	var out []int
+	if err := cbor.Unmarshal(inner, &out); err != nil {
+		t.Fatalf("inner array unmarshal failed: %v", err)
+	}
+	return out
+}
+
+func TestCostModelV1EncodingSmall(t *testing.T) {
+	// <24 entries: the outer bytestring header fits in one byte.
+	in := PlutusData.CostModel{1, 2, 3}
+	got, err := PlutusData.CostModelV1Encoding(in).MarshalCBOR()
+	if err != nil {
+		t.Fatalf("MarshalCBOR: %v", err)
+	}
+	// Bytestring of length 5 (9f 01 02 03 ff).
+	want, _ := hex.DecodeString("459f010203ff")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("small case bytes mismatch:\n got  %x\n want %x", got, want)
+	}
+	if decoded := decodeCostModelV1(t, got); !equalInts(decoded, []int(in)) {
+		t.Fatalf("round-trip mismatch: got %v want %v", decoded, []int(in))
+	}
+}
+
+func TestCostModelV1EncodingMedium(t *testing.T) {
+	// 24..255 entries: header is two bytes (0x58 <len>).
+	in := make(PlutusData.CostModel, 30)
+	for i := range in {
+		in[i] = i
+	}
+	got, err := PlutusData.CostModelV1Encoding(in).MarshalCBOR()
+	if err != nil {
+		t.Fatalf("MarshalCBOR: %v", err)
+	}
+	if got[0] != 0x58 {
+		t.Fatalf("expected 0x58-prefixed bytestring, got first byte %#x", got[0])
+	}
+	if decoded := decodeCostModelV1(t, got); !equalInts(decoded, []int(in)) {
+		t.Fatalf("round-trip mismatch: got %v want %v", decoded, []int(in))
+	}
+}
+
+func TestCostModelV1EncodingLarge(t *testing.T) {
+	// >=256 entries: header is three bytes (0x59 <len-hi> <len-lo>).
+	// The pre-patch CM.MarshalCBOR corrupted the length prefix at this size
+	// because it unconditionally overwrote partial[1] with 0x9f; this test
+	// guards against a regression to that behaviour.
+	in := make(PlutusData.CostModel, 332)
+	for i := range in {
+		in[i] = 100788 + i
+	}
+	got, err := PlutusData.CostModelV1Encoding(in).MarshalCBOR()
+	if err != nil {
+		t.Fatalf("MarshalCBOR: %v", err)
+	}
+	if got[0] != 0x59 {
+		t.Fatalf("expected 0x59-prefixed bytestring for 332-entry cost model, got first byte %#x", got[0])
+	}
+	if decoded := decodeCostModelV1(t, got); !equalInts(decoded, []int(in)) {
+		t.Fatalf("round-trip mismatch: len(got)=%d len(want)=%d", len(decoded), len(in))
+	}
+}
+
+func TestCostModelV2Passthrough(t *testing.T) {
+	// V2 and V3 now both encode as a plain definite-length CBOR array of
+	// ints in the order the chain context supplied. This test asserts the
+	// exact bytes for a small array and the round-trip for a large one.
+	in := PlutusData.CostModel{1, 2, 3}
+	got, err := PlutusData.CostModelV2(in).MarshalCBOR()
+	if err != nil {
+		t.Fatalf("MarshalCBOR: %v", err)
+	}
+	want, _ := hex.DecodeString("83010203")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("V2 small bytes mismatch:\n got  %x\n want %x", got, want)
+	}
+
+	large := make(PlutusData.CostModel, 332)
+	for i := range large {
+		large[i] = 100788 + i
+	}
+	gotLarge, err := PlutusData.CostModelV2(large).MarshalCBOR()
+	if err != nil {
+		t.Fatalf("MarshalCBOR large: %v", err)
+	}
+	var round []int
+	if err := cbor.Unmarshal(gotLarge, &round); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if !equalInts(round, []int(large)) {
+		t.Fatalf("V2 large round-trip mismatch: len(got)=%d len(want)=%d", len(round), len(large))
+	}
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

`CostModelV1` and `CostModelV2` remap the ogmios cost model array through a hardcoded parameter name list (166 entries for V1, 175 for V2). Any entries beyond that cap get silently dropped from the language-view encoding, so the `script_data_hash` apollo computes diverges from the node's whenever the ledger's cost models grow past those lengths.

A recent preview protocol parameter update pushed both V1 and V2 to **332 entries** (V3 to 350). That broke every transaction with a V1/V2 script in the language view — direct *or* via reference scripts — with ledger error `3113` (script integrity hash mismatch). Production mainnet will hit this too once the same update lands.

This PR makes `CostModelV1` / `CostModelV2` forward the cost model slice verbatim, in the canonical parameter order ogmios already returns (the same order the ledger uses to compute its own view), mirroring how `CostModelV3` already worked. The new `CostModelV1Encoding` type handles the CIP-35 Alonzo V1 envelope (indefinite-length array wrapped as a CBOR bytestring) without a fixed length assumption.

As a side benefit, this also fixes a latent bug in `CM.MarshalCBOR` where the old V1 path would corrupt its CBOR length prefix byte for arrays of 256 or more entries (it unconditionally wrote `0x9f` at `partial[1]`, which is the high length byte for `0x99`-tagged arrays).

`V1COSTMODELKEYS` / `V2COSTMODELKEYS` / `CM` / `CostView` are left exported so any external caller that imported them still compiles; nothing in this repo references them after this change.

## Test plan

- [x] Verified on Cardano preview: scooper built against this patch runs clean scoops across both V3 (sundae-v3) and stableswap pools. Before the fix: 100% of submissions failed with error 3113 (`providedScriptIntegrity != computedScriptIntegrity`); after: clean runs.
- [x] Independent code review covering CBOR correctness for small (<24), medium (24–255), and large (≥256) arrays, ogmios parameter-order assumption, backward compat.
- [x] Unit tests for `CostModelV1Encoding.MarshalCBOR` across all three size classes (guards the ≥256-entry length-prefix bug) and the V2 passthrough path (pins small-case bytes and round-trips a 332-entry model).