### PR TITLE
support long cbor tags

### DIFF
--- a/serialization/PlutusData/PlutusData.go
+++ b/serialization/PlutusData/PlutusData.go
@@ -1401,6 +1401,26 @@ func (pd *PlutusData) UnmarshalJSON(value []byte) error {
 	return nil
 }
 
+// tagHeaderLen returns the number of bytes occupied by a CBOR tag's major
+// type byte plus its argument, based on the additional-info bits in the
+// leading byte. Constructor tags 121-127 fit in a single extra byte (2-byte
+// header), but constructor tags 1280-1400 (alternatives 7-127) need a 2-byte
+// argument (3-byte header) - assuming a fixed 2-byte header corrupts those.
+func tagHeaderLen(b byte) int {
+	switch b & 0x1f {
+	case 24:
+		return 2
+	case 25:
+		return 3
+	case 26:
+		return 5
+	case 27:
+		return 9
+	default:
+		return 1
+	}
+}
+
 func (pd *PlutusData) UnmarshalCBOR(value []uint8) error {
 	var x any
 	err := cbor.Unmarshal(value, &x)
@@ -1413,16 +1433,17 @@ func (pd *PlutusData) UnmarshalCBOR(value []uint8) error {
 		case []interface{}:
 			pd.TagNr = ok.Number
 			pd.PlutusDataType = PlutusArray
-			if value[2] == 0x9f {
+			headerLen := tagHeaderLen(value[0])
+			if value[headerLen] == 0x9f {
 				y := PlutusIndefArray{}
-				err = cbor.Unmarshal(value[2:], &y)
+				err = cbor.Unmarshal(value[headerLen:], &y)
 				if err != nil {
 					return err
 				}
 				pd.Value = y
 			} else {
 				y := PlutusDefArray{}
-				err = cbor.Unmarshal(value[2:], &y)
+				err = cbor.Unmarshal(value[headerLen:], &y)
 				if err != nil {
 					return err
 				}

--- a/tests/serialization/PlutusData/PlutusData_test.go
+++ b/tests/serialization/PlutusData/PlutusData_test.go
@@ -307,6 +307,24 @@ func TestPlutusDataFromJson(t *testing.T) {
 
 }
 
+func TestRoundTripNestedConstrDatum(t *testing.T) {
+	var pd PlutusData.PlutusData
+	datumBytes, err := hex.DecodeString("d8799fd8799f581c4a9f827cdfe7036bf395c7d4304ea3fc1050c420282ac68cb8a1a7b5ffd8799fd8799f581c4a9f827cdfe7036bf395c7d4304ea3fc1050c420282ac68cb8a1a7b5ffd8799fd8799fd8799f581c1e376f232be5a1fa620c5a4b109b8587ec3142dd4876b6bd32ad0beeffffffffd87980d8799fd8799f581c4a9f827cdfe7036bf395c7d4304ea3fc1050c420282ac68cb8a1a7b5ffd8799fd8799fd8799f581c1e376f232be5a1fa620c5a4b109b8587ec3142dd4876b6bd32ad0beeffffffffd87980d8799f581cf5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c58208996cebb9511cf1e6584abd92667e26cf7034bfe805ac618e2e6a14992198873ffd905029f9fd8799fd8799f581cf5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c58208996cebb9511cf1e6584abd92667e26cf7034bfe805ac618e2e6a14992198873ffd87980ffd8799fd8799f581cf5808c2c990d86da54bfc97d89cee6efa20cd8461616359478d96b4c5820e74c52975908a612d5ce68327040d449aae99f8b463bb6de046a1b23c5713169ffd87a80ffffd87a9f00ff1a00030b8bff1a001e8480d87a80ff")
+	if err != nil {
+		t.Fatalf("couldn't decode hex: %v", err)
+	}
+	if err := cbor.Unmarshal(datumBytes, &pd); err != nil {
+		t.Fatalf("couldn't decode: %v", err)
+	}
+	newBytes, err := cbor.Marshal(pd)
+	if err != nil {
+		t.Fatalf("couldn't encode: %v", err)
+	}
+	if !bytes.Equal(datumBytes, newBytes) {
+		t.Errorf("failed roundtrip:\n got  %s\n want %s", hex.EncodeToString(newBytes), hex.EncodeToString(datumBytes))
+	}
+}
+
 func TestRoundTripDefiniteDatum(t *testing.T) {
 	var pd PlutusData.PlutusData
 	datumBytes, err := hex.DecodeString("d879844100d87982d87982d87982d87981581c49ce0fc15732f1bb8c9c82f2224329a49cbb41e81c52e8a7fce5cf98d87a80d87a80d87a801a002625a0d87983d879801903e8d879811903e8")


### PR DESCRIPTION
support cbor tags that take up more than 2 bytes; this happens in plutus datums representing values of sum types with more than 8 variants.